### PR TITLE
Simplify compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 ## Compile
 
 ```
-mkdir go
-export GOLANG=$(pwd)/go
-cd go ; mkdir -p src/0xcc.re
-cd src/0xcc.re
+export GOLANG="$PWD/go"
+mkdir -p go/src/0xcc.re
+cd go/src/0xcc.re
 git clone https://github.com/mikalv/anything2ed25519.git
 cd anything2ed25519
 ./build.sh


### PR DESCRIPTION
No need to run `pwd` if we already have `$PWD` at our disposal - also,
quote it in case there's a space character in our directory path.

While there, we can skip one instance of `cd` and `mkdir` as we aren't running
anything else apart from another `mkdir` once we had `cd`'ed into `"$PWD/go"`.